### PR TITLE
Don't create streams for unsupported sources

### DIFF
--- a/tap_crossbeam/discover.py
+++ b/tap_crossbeam/discover.py
@@ -160,7 +160,7 @@ def _records_streams(client):
     for source in client.yield_sources():
         if not source['mdm_type']:
             continue
-        if source['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+        if source['mdm_type'] not in ['account', 'lead', 'user']:
             continue
         stream_name = source['mdm_type']
         _initialize_stream(streams, stream_name)
@@ -180,7 +180,7 @@ def _partner_records_streams(client):
     for shared_field in client.yield_partner_shared_fields():
         if not shared_field['mdm_type']:
             continue
-        if shared_field['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+        if shared_field['mdm_type'] not in ['account', 'lead', 'user']:
             continue
         stream_name = 'partner_' + shared_field['mdm_type']
         _initialize_stream(streams, stream_name)

--- a/tap_crossbeam/discover.py
+++ b/tap_crossbeam/discover.py
@@ -160,6 +160,8 @@ def _records_streams(client):
     for source in client.yield_sources():
         if not source['mdm_type']:
             continue
+        if source['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+            continue
         stream_name = source['mdm_type']
         _initialize_stream(streams, stream_name)
         fields = [
@@ -177,6 +179,8 @@ def _partner_records_streams(client):
     streams = {}
     for shared_field in client.yield_partner_shared_fields():
         if not shared_field['mdm_type']:
+            continue
+        if shared_field['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
             continue
         stream_name = 'partner_' + shared_field['mdm_type']
         _initialize_stream(streams, stream_name)


### PR DESCRIPTION
# Description of change

There are a few sources that we were creating during discovery which aren't actually supported. This led to an issue when testing the integration inside Stitch. Stitch checks that the primary key value defined by the stream is included as a property in the schema, which we were not doing properly.

I updated the code to exclude those streams from discovery.

# Manual QA steps

 - Ran discovery, confirmed the unsupported streams for you and partner are no longer included
 
# Risks

 - 
 
# Rollback steps
 - revert this branch
