### PR TITLE
Fix primary keys for partner streams

### DIFF
--- a/tap_crossbeam/discover.py
+++ b/tap_crossbeam/discover.py
@@ -160,7 +160,7 @@ def _records_streams(client):
     for source in client.yield_sources():
         if not source['mdm_type']:
             continue
-        if source['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+        if source['mdm_type'] not in ['account', 'lead', 'user']:
             continue
         stream_name = source['mdm_type']
         _initialize_stream(streams, stream_name)
@@ -180,7 +180,7 @@ def _partner_records_streams(client):
     for shared_field in client.yield_partner_shared_fields():
         if not shared_field['mdm_type']:
             continue
-        if shared_field['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+        if shared_field['mdm_type'] not in ['account', 'lead', 'user']:
             continue
         stream_name = 'partner_' + shared_field['mdm_type']
         _initialize_stream(streams, stream_name)

--- a/tap_crossbeam/discover.py
+++ b/tap_crossbeam/discover.py
@@ -141,6 +141,14 @@ STANDARD_KEYS = {
         '_partner_crossbeam_id': STRING,
     },
 }
+PRIMARY_KEYS = {
+    'account': ['_crossbeam_id'],
+    'lead': ['_crossbeam_id'],
+    'user': ['_crossbeam_id'],
+    'partner_account': ['_crossbeam_id', '_partner_crossbeam_id'],
+    'partner_lead': ['_crossbeam_id', '_partner_crossbeam_id'],
+    'partner_user': ['_partner_crossbeam_id'],
+}
 
 
 def _initialize_stream(streams, stream_name):
@@ -234,7 +242,7 @@ def discover(client):
             catalog.streams.append(CatalogEntry(
                 stream=stream_name,
                 tap_stream_id=stream_name,
-                key_properties=['_crossbeam_id'],
+                key_properties=PRIMARY_KEYS[stream_name],
                 schema=schema,
                 metadata=metadata
             ))

--- a/tap_crossbeam/discover.py
+++ b/tap_crossbeam/discover.py
@@ -160,6 +160,8 @@ def _records_streams(client):
     for source in client.yield_sources():
         if not source['mdm_type']:
             continue
+        if source['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
+            continue
         stream_name = source['mdm_type']
         _initialize_stream(streams, stream_name)
         fields = [
@@ -177,6 +179,8 @@ def _partner_records_streams(client):
     streams = {}
     for shared_field in client.yield_partner_shared_fields():
         if not shared_field['mdm_type']:
+            continue
+        if shared_field['mdm_type'] not in ['account', 'deal', 'lead', 'user']:
             continue
         stream_name = 'partner_' + shared_field['mdm_type']
         _initialize_stream(streams, stream_name)


### PR DESCRIPTION
# Description of change

Unfortunately there was another issue with primary key values not aligning with the schema. This time around, I used a script to test the behavior across all streams:

```python
#!/usr/bin/env python
import json
import sys

with open(sys.argv[1]) as fp:
    catalog = json.load(fp)


bad = []

for stream in catalog["streams"]:
    for key in stream["key_properties"]:
        if key not in stream["schema"]["properties"]:
            bad.append((stream["tap_stream_id"], key))

for b in bad:
    print(b)
```

This pointed out an issue with at least the `partner_user` stream. But I noticed in the process that the `key_properties` for the other partner streams were incorrect too, as they all used `_crossbeam_id` as the key.

After this change, the above script reports no issues.

# Manual QA steps

 - As said above, used that script to check the key_properties all exist in the stream properties
 - Ran discovery and sync and uploaded this data into BigQuery
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
