### PR TITLE
bumped version to 0.4.0 and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.0
+  * Implements bookmarking [#8](https://github.com/singer-io/tap-crossbeam/pull/8)
+
 ## 0.3.0
   * Updated primary keys [#6](https://github.com/singer-io/tap-crossbeam/pull/6)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-crossbeam',
-      version='0.3.0',
+      version='0.4.0',
       description='Singer.io tap for extracting data from the Crossbeam API',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_crossbeam'],


### PR DESCRIPTION
# Description of change
bumped version to 0.4.0 and updated changelog

# Manual QA steps
 -  none
 
# Risks
 - low, crossbeam is the only one using this tap at the moment and they're the ones that made the change
 
# Rollback steps
 - revert this branch
